### PR TITLE
Fixes unexpected behavior with inline increment operator

### DIFF
--- a/ref-impl/src/impl/AAFUtils.cpp
+++ b/ref-impl/src/impl/AAFUtils.cpp
@@ -184,7 +184,7 @@ aafErr_t AAFConvertEditRate(
 		{
 			*destPosition = destPos;
 			if(remainder != 0)
-				*destPosition++;
+				*destPosition = *destPosition + 1;
 		}
 	} /* XPROTECT */
 	XEXCEPT


### PR DESCRIPTION
I have noted sometimes desPosition can remain unchanged with newer versions of Visual Studio. It isn't so easy to reproduce but writing this line instead has solved this issue.